### PR TITLE
fix: add missing raise statements

### DIFF
--- a/src/majsoulrpa/yostar_login/_yostar_login.py
+++ b/src/majsoulrpa/yostar_login/_yostar_login.py
@@ -164,7 +164,7 @@ class YostarLoginIMAP(YostarLoginBase):
                 "Timeout is longer than verification code expiration. "
                 "Set the timeout to 30 minutes or less."
             )
-            ValueError(msg)
+            raise ValueError(msg)
 
         while True:
             auth_code = self._get_auth_code(start_time=start_time)
@@ -313,7 +313,7 @@ class YostarLoginS3(YostarLoginBase):
                 "Timeout is longer than verification code expiration. "
                 "Set the timeout to 30 minutes or less."
             )
-            ValueError(msg)
+            raise ValueError(msg)
 
         while True:
             auth_code = self._get_auth_code(start_time=start_time)


### PR DESCRIPTION
I think `raise` statements are missing, so please correct them.