### PR TITLE
Fix AngangJiagangEvent

### DIFF
--- a/src/majsoulrpa/presentation/match/event/angangjiagang.py
+++ b/src/majsoulrpa/presentation/match/event/angangjiagang.py
@@ -14,7 +14,7 @@ class AngangJiagangEvent(EventBase):
     ) -> None:
         super().__init__(timestamp)
         self._seat = data["seat"]
-        self._type = (None, None, "暗槓", "加槓")[data["type"]]
+        self._type = (None, None, "加槓", "暗槓")[data["type"]]
         self._tile = data["tiles"]
 
     @property
@@ -25,7 +25,7 @@ class AngangJiagangEvent(EventBase):
 
     @property
     def type_(self) -> str:
-        assert self._type in ("暗槓", "加槓")
+        assert self._type in ("加槓", "暗槓")
         return self._type
 
     @property


### PR DESCRIPTION
`AngangJiagangEvent` は ActionAnGangAddGang から作成されます。type が 2 のときは加槓、3 のときは暗槓となります。実装では逆となっているため修正します。

L28 の順番は実行結果に影響がありませんが順番を統一させるために更新しています。

ref: https://wikiwiki.jp/majsoul-api/%E3%83%87%E3%83%BC%E3%82%BF%E5%9E%8B%28A~G%29%E4%B8%80%E8%A6%A7%E3%81%AB%E3%82%83#ActionAnGangAddGang