### PR TITLE
Fixed tiles type in ChiPengGangEvent

### DIFF
--- a/src/majsoulrpa/presentation/match/event/chipenggang.py
+++ b/src/majsoulrpa/presentation/match/event/chipenggang.py
@@ -33,5 +33,5 @@ class ChiPengGangEvent(EventBase):
         return self._from
 
     @property
-    def tiles(self) -> str:
+    def tiles(self) -> list[str]:
         return self._tiles


### PR DESCRIPTION
ActionChiPengGang の `tiles` フィールドは repeated であるため `list[str]` となります。

ref: https://wikiwiki.jp/majsoul-api/%E3%83%87%E3%83%BC%E3%82%BF%E5%9E%8B%28A~G%29%E4%B8%80%E8%A6%A7%E3%81%AB%E3%82%83#ActionChiPengGang