### PR TITLE
fix: left position is wrong when shopai tile count is 1

### DIFF
--- a/src/majsoulrpa/presentation/match/match.py
+++ b/src/majsoulrpa/presentation/match/match.py
@@ -1414,7 +1414,7 @@ class MatchPresentation(PresentationBase):
                 case 4:
                     left = 633
                 case 1:
-                    left = 224
+                    left = 348
                 case _:
                     raise AssertionError
         else:


### PR DESCRIPTION
手牌の数が1枚の状態で、山から牌を取り出し打牌するとき、自摸切りをすることができない。この問題を解消する修正差分です。

zimopai の位置のハードコードすべきところが、誤って手牌の最も左の位置となっています。