### PR TITLE
feat: add doras property

### DIFF
--- a/src/majsoulrpa/presentation/match/event/dapai.py
+++ b/src/majsoulrpa/presentation/match/event/dapai.py
@@ -18,6 +18,7 @@ class DapaiEvent(EventBase):
         self._moqie = data["moqie"]
         self._liqi = data["is_liqi"]
         self._wliqi = data["is_wliqi"]
+        self._doras = data["doras"]
 
     @property
     def seat(self) -> int:
@@ -40,3 +41,7 @@ class DapaiEvent(EventBase):
     @property
     def wliqi(self) -> bool:
         return self._wliqi
+
+    @property
+    def doras(self) -> list[str]:
+        return self._doras


### PR DESCRIPTION
機能拡張の提案差分です。AIプログラムへの入力を作成するとき `MatchPresentation._events: list[EventBase]` からコンバートして用いています。しかし `_events` にはカンしたあとに追加されるドラ表示牌の情報が含まれていないため、牌譜を完全に表現することができません。
`ActionDiscardTile` にこの情報が含まれていますが、対応する `DapaiEvent` オブジェクトを作成するときに捨てています。この情報を保持するように変更する提案の差分です。