### PR TITLE
fix: handle ActionMJStart on sync game

### DIFF
--- a/src/majsoulrpa/presentation/match/match.py
+++ b/src/majsoulrpa/presentation/match/match.py
@@ -1031,6 +1031,8 @@ class MatchPresentation(PresentationBase):
 
         action = actions.pop(0)
         step, name, data = _common.parse_action(action, restore=True)
+        self._step = 0
+
         if step != 0:
             raise InconsistentMessageError(str(action))
 
@@ -1046,7 +1048,7 @@ class MatchPresentation(PresentationBase):
 
         if name != "ActionNewRound":
             raise InconsistentMessageError(str(action))
-        self._step = 0
+
         self._events.clear()
         self._events.append(NewRoundEvent(data, timestamp))
         self._round_state = RoundState(self._match_state, data)

--- a/src/majsoulrpa/presentation/match/match.py
+++ b/src/majsoulrpa/presentation/match/match.py
@@ -1033,6 +1033,17 @@ class MatchPresentation(PresentationBase):
         step, name, data = _common.parse_action(action, restore=True)
         if step != 0:
             raise InconsistentMessageError(str(action))
+
+        if name == "ActionMJStart":
+            if len(actions) == 0:
+                raise InconsistentMessageError(str(message))
+
+            action = action.pop(0)
+            step, name, data = _common.parse_action(action, restore=True)
+            if step != 1:
+                raise InconsistentMessageError(str(action))
+            self._step += 1
+
         if name != "ActionNewRound":
             raise InconsistentMessageError(str(action))
         self._step = 0


### PR DESCRIPTION
通信状況が悪い場合の同期処理について。同期のために受け取るデータの最初の Action が `ActionNewRound` ではなく `ActionMJStart` であることがあります。現在のコードではこの対応ができていないため、対応できるようにする差分となります。

参考までに、ロガーに表示されたデータは以下のようになります。

```
(
  'outbound',
  'lq.FastTest.syncGame',
  {
    'round_id': '0-0-0',
    'step': 4294967295
  },
  {
    'step': 44,
    'game_restore': {
      'actions': [
        {
          'name': 'ActionMJStart',
          'step': 0,
          'data': ''
        },
        {
          'step': 1,
          'name': 'ActionNewRound',
          'data': '****'
        },
        {
           'step': 2,
           'name': 'ActionDiscardTile',
           'data': '****'
        },
        {
          'step': 3,
          'name': 'ActionDealTile',
          'data': '****'
        },
        ...
```
```