### PR TITLE
Fix/move mouse

### DIFF
--- a/src/majsoulrpa/_impl/browser.py
+++ b/src/majsoulrpa/_impl/browser.py
@@ -26,7 +26,7 @@ MAX_WIDTH: Final[int] = STD_WIDTH * 2
 MAX_HEIGHT: Final[int] = STD_HEIGHT * 2
 ASPECT_RATIO: Final[Fraction] = Fraction(16, 9)
 
-MAX_LATENCY: Final[int] = 1_000  # ms
+MAX_LATENCY: Final[int] = 2_000  # ms
 
 
 def validate_viewport_size(width: int, height: int) -> None:

--- a/src/majsoulrpa/presentation/match/match.py
+++ b/src/majsoulrpa/presentation/match/match.py
@@ -183,6 +183,18 @@ class MatchPresentation(PresentationBase):
         self._match_state = match_state
         self._operation_list = None
 
+        # If the mouse cursor is placed over the tiles in the hand,
+        # winning tile candidates may be displayed and interfere with
+        # template matching. Therefore, move the mouse cursor to an
+        # appropriate position where there are no tiles in the hand.
+        self._browser.move_to_region(
+            int(986 * self._browser.zoom_ratio),
+            int(806 * self._browser.zoom_ratio),
+            int(134 * self._browser.zoom_ratio),
+            int(57 * self._browser.zoom_ratio),
+            edge_sigma=1.0,
+        )
+
         paths = [f"template/match/marker{i}" for i in range(4)]
         templates = [Template.open_file(p, browser.zoom_ratio) for p in paths]
         ss = browser.get_screenshot()
@@ -1452,6 +1464,11 @@ class MatchPresentation(PresentationBase):
         width = int(width * self._browser.zoom_ratio)
         height = int(height * self._browser.zoom_ratio)
 
+        # Clicking won't discard a tile unless it position the mouse
+        # cursor over it in advance.
+        self._browser.move_to_region(left, top, width, height, edge_sigma=1.0)
+        time.sleep(0.04)
+
         # `timeout=5.0` may be too short
         # when the screen display freezes.
         self._robust_click_region(
@@ -1461,6 +1478,18 @@ class MatchPresentation(PresentationBase):
             height,
             interval=1.0,
             timeout=25.0,
+            edge_sigma=1.0,
+        )
+
+        # If the mouse cursor is placed over the tiles in the hand,
+        # winning tile candidates may be displayed and interfere with
+        # template matching. Therefore, move the mouse cursor to an
+        # appropriate position where there are no tiles in the hand.
+        self._browser.move_to_region(
+            int(986 * self._browser.zoom_ratio),
+            int(806 * self._browser.zoom_ratio),
+            int(134 * self._browser.zoom_ratio),
+            int(57 * self._browser.zoom_ratio),
             edge_sigma=1.0,
         )
 

--- a/src/majsoulrpa/presentation/match/match.py
+++ b/src/majsoulrpa/presentation/match/match.py
@@ -1533,7 +1533,7 @@ class MatchPresentation(PresentationBase):
                     # don't wait until the effect ends before playing
                     # the tiles, you may end up clicking on an
                     # unintended tile and discarding it.
-                    time.sleep(1.0)
+                    time.sleep(2.0)
                 if index is None:
                     msg = "Index not specified."
                     raise InvalidOperationError(

--- a/src/majsoulrpa/remote_browser/_remote_browser.py
+++ b/src/majsoulrpa/remote_browser/_remote_browser.py
@@ -136,6 +136,12 @@ def _launch_remote_browser_core(
                     page.keyboard.press(keys)
                     response = {"result": "O.K."}
                     socket.send_json(response)
+                case "move":
+                    x = request["x"]
+                    y = request["y"]
+                    page.mouse.move(x, y)
+                    response = {"result": "O.K."}
+                    socket.send_json(response)
                 case "scroll":
                     response = {"result": "Error: Not implemented."}
                     socket.send_json(response)


### PR DESCRIPTION
## 1. 打牌時に1回目のクリックが不発になる現象の解決

牌にマウスが乗ると牌が持ち上がって打牌可能となり、持ち上がった牌をクリックすると打牌される
現状の動作ではマウスが乗るのとクリックがほぼ同時であったため、牌が持ち上がるまでにクリックが完了してしまっていた
そのため1回目のクリックでは打牌がされていなかった

対策として、一旦マウスを牌の上に置き、打牌可能になるまでの待ち時間を設ける
検証したところ牌にマウスを置いてから打牌可能になるまで(牌が持ち上がるまで)は0.01秒以上0.02秒以下のようであるが、マージンをとって待ち時間は0.04秒とする

## 2. 和了牌のアシスト表示がテンプレートマッチングの妨げになっている現象の解決

現状の動作では打牌後マウスは牌をクリックした位置にそのまま残る
マウスが乗っている牌を切ると聴牌する場合、切った場合の和了牌が表示される
このアシスト表示が副露や立直などのボタンをクリックする際のテンプレートマッチングの妨げとなっている

対策として、打牌後は手牌がない範囲にマウスを移動させることで牌にマウスが乗らないようにする
ダブル立直や天和などに対応するため、開局時、つまりMatchPresentationの生成時も同様の処理をする