### PR TITLE
Feat/restore from rendering problems in matches

### DIFF
--- a/examples/join_room_restore.py
+++ b/examples/join_room_restore.py
@@ -1,0 +1,149 @@
+import time
+import traceback
+from logging import INFO, StreamHandler, basicConfig
+
+from majsoulrpa import RPA, config
+from majsoulrpa.presentation import (
+    AuthPresentation,
+    BaseError,
+    HomePresentation,
+    LoginPresentation,
+    RoomGuestPresentation,
+)
+from majsoulrpa.presentation.match import MatchPresentation
+from majsoulrpa.presentation.match.operation import (
+    BabeiOperation,
+    DapaiOperation,
+)
+
+LOG_LEVEL = INFO
+stream_handler = StreamHandler()
+stream_handler.setLevel(LOG_LEVEL)
+basicConfig(level=LOG_LEVEL, handlers=[stream_handler])
+
+if __name__ == "__main__":
+    my_config = config.get_config("examples/config.toml")
+
+    try:
+        with RPA.from_config(my_config) as rpa:
+            presentation = rpa.wait(timeout=20.0)
+
+            if not isinstance(presentation, MatchPresentation):
+                if not isinstance(presentation, HomePresentation):
+                    if not isinstance(presentation, LoginPresentation):
+                        msg = "Could not transit to `login`."
+                        raise RuntimeError(msg)
+                    presentation.login(timeout=60.0)
+                    if presentation.new_presentation is None:
+                        msg = "Could not transit to `auth`."
+                        raise RuntimeError(msg)
+                    presentation = presentation.new_presentation
+
+                    if not isinstance(presentation, AuthPresentation):
+                        msg = "Could not transit to `auth`."
+                        raise RuntimeError(msg)
+                    presentation.enter_email_address(
+                        my_config["authentication"]["email_address"],
+                    )
+                    auth_code = input("verification code: ")
+                    presentation.enter_auth_code(auth_code, timeout=60.0)
+                    if presentation.new_presentation is None:
+                        msg = "Could not transit to `home`."
+                        raise RuntimeError
+                    presentation = presentation.new_presentation
+
+                if not isinstance(presentation, HomePresentation):
+                    msg = "Could not transit to `home`."
+                    raise RuntimeError(msg)
+                room_id = str(input("room id: "))
+                reason = presentation.join_room(room_id)
+                if presentation.new_presentation is None:
+                    assert reason is not None
+                    msg = f"Could not transit to `room`. Reason: {reason.name}"
+                    raise RuntimeError(msg)
+                presentation = presentation.new_presentation
+
+                if not isinstance(presentation, RoomGuestPresentation):
+                    msg = "Could not transit to `room`."
+                    raise RuntimeError(msg)
+                print(f"room id: {presentation.room_id}")
+
+                presentation.ready(timeout=30.0)
+                if presentation.new_presentation is None:
+                    msg = "Could not transit to `match`."
+                    raise RuntimeError(msg)
+                presentation = presentation.new_presentation
+
+            if not isinstance(presentation, MatchPresentation):
+                msg = "Could not transit to `match`."
+                raise RuntimeError(msg)
+
+            seat = None
+            for i, player in enumerate(presentation.players):
+                if player.account_id == rpa.get_account_id():
+                    assert seat is None
+                    seat = i
+                print(
+                    f"{player.name} ({player.level4}, {player.character})",
+                )
+            assert seat is not None
+            changs = ["東", "南", "西", "北"]
+            print(
+                f"{changs[presentation.chang]}{presentation.ju + 1}局"
+                f"{presentation.ben}本場 (供託{presentation.liqibang}本)",
+            )
+            print(
+                "スコア: "
+                f"{','.join([str(s) for s in presentation.scores])}",
+            )
+            print(f"表ドラ表示牌: {presentation.dora_indicators[0]}")
+            print(f"自風: {changs[seat]}")
+            print(f"手牌: {','.join(presentation.shoupai)}")
+            if presentation.zimopai is not None:
+                print(f"自摸牌: {presentation.zimopai}")
+
+            while True:
+                ops = presentation.operation_list
+                if ops is not None:
+                    op = None
+                    babei = False
+                    for op in ops:
+                        if isinstance(op, BabeiOperation):
+                            babei = True
+                            break
+                    if babei:
+                        time.sleep(0.1)
+                        presentation.select_operation(op)
+                        continue
+
+                    moqie = False
+                    for op in ops:
+                        if isinstance(op, DapaiOperation):
+                            moqie = True
+                            break
+                    if moqie:
+                        time.sleep(0.1)
+                        presentation.select_operation(op, 13)
+                    else:
+                        presentation.select_operation(None)
+                else:
+                    presentation.wait()
+
+                if presentation.new_presentation is not None:
+                    presentation = presentation.new_presentation
+                    if isinstance(presentation, MatchPresentation):
+                        continue
+                    assert isinstance(presentation, RoomGuestPresentation)
+                    break
+
+            presentation.leave()
+
+            if presentation.new_presentation is None:
+                msg = "Could not transit to `home`."
+                raise RuntimeError(msg)
+            presentation = presentation.new_presentation
+
+            time.sleep(5.0)
+    except BaseError as e:
+        e.save_screenshot()
+        traceback.print_exc()

--- a/src/majsoulrpa/_rpa.py
+++ b/src/majsoulrpa/_rpa.py
@@ -19,6 +19,7 @@ from .presentation.exceptions import (
     PresentationNotDetectedError,
     PresentationTimeoutError,
 )
+from .presentation.match import MatchPresentation
 from .presentation.presentation_base import PresentationBase
 
 if TYPE_CHECKING:
@@ -431,6 +432,20 @@ class RPA:
                     self._browser,
                     self._message_queue_client,
                     self._creator,
+                    deadline - now,
+                )
+            except PresentationNotDetectedError:
+                pass
+            else:
+                return p
+
+            try:
+                now = datetime.datetime.now(datetime.UTC)
+                p = MatchPresentation(
+                    self._browser,
+                    self._message_queue_client,
+                    self._creator,
+                    None,
                     deadline - now,
                 )
             except PresentationNotDetectedError:

--- a/src/majsoulrpa/presentation/match/match.py
+++ b/src/majsoulrpa/presentation/match/match.py
@@ -270,76 +270,65 @@ class MatchPresentation(PresentationBase):
             if step != self._step:
                 raise InconsistentMessageError(str(action))
 
-            if name == "ActionDealTile":
-                self._events.append(ZimoEvent(data, timestamp))
-                self._round_state._on_zimo(data)  # noqa: SLF001
-                if ("operation" in data) and len(
-                    data["operation"]["operation_list"],
-                ) > 0:
-                    self._operation_list = OperationList(data["operation"])
-                else:
-                    self._operation_list = None
-                self._step += 1
-                continue
-
-            if name == "ActionDiscardTile":
-                self._events.append(DapaiEvent(data, timestamp))
-                self._round_state._on_dapai(data)  # noqa: SLF001
-                if ("operation" in data) and len(
-                    data["operation"]["operation_list"],
-                ) > 0:
-                    self._operation_list = OperationList(data["operation"])
-                else:
-                    self._operation_list = None
-                self._step += 1
-                continue
-
-            if name == "ActionChiPengGang":
-                self._events.append(ChiPengGangEvent(data, timestamp))
-                self._round_state._on_chipenggang(data)  # noqa: SLF001
-                if ("operation" in data) and len(
-                    data["operation"]["operation_list"],
-                ) > 0:
-                    self._operation_list = OperationList(data["operation"])
-                else:
-                    self._operation_list = None
-                self._step += 1
-                continue
-
-            if name == "ActionAnGangAddGang":
-                self._events.append(AngangJiagangEvent(data, timestamp))
-                self._round_state._on_angang_jiagang(data)  # noqa: SLF001
-                if ("operation" in data) and len(
-                    data["operation"]["operation_list"],
-                ) > 0:
-                    self._operation_list = OperationList(data["operation"])
-                else:
-                    self._operation_list = None
-                self._step += 1
-                continue
-
-            if name == "ActionBaBei":
-                self._events.append(BabeiEvent(data, timestamp))
-                self._round_state._on_babei(data)  # noqa: SLF001
-                if ("operation" in data) and len(
-                    data["operation"]["operation_list"],
-                ) > 0:
-                    self._operation_list = OperationList(data["operation"])
-                else:
-                    self._operation_list = None
-                self._step += 1
-                continue
-
-            if name == "ActionHule":
-                raise InconsistentMessageError(str(action))
-
-            if name == "ActionNoTile":
-                raise InconsistentMessageError(str(action))
-
-            if name == "ActionLiuJu":
-                raise InconsistentMessageError(str(action))
-
-            raise InconsistentMessageError(str(action))
+            match name:
+                case "ActionDealTile":
+                    self._events.append(ZimoEvent(data, timestamp))
+                    self._round_state._on_zimo(data)  # noqa: SLF001
+                    if ("operation" in data) and len(
+                        data["operation"]["operation_list"],
+                    ) > 0:
+                        self._operation_list = OperationList(data["operation"])
+                    else:
+                        self._operation_list = None
+                    self._step += 1
+                case "ActionDiscardTile":
+                    self._events.append(DapaiEvent(data, timestamp))
+                    self._round_state._on_dapai(data)  # noqa: SLF001
+                    if ("operation" in data) and len(
+                        data["operation"]["operation_list"],
+                    ) > 0:
+                        self._operation_list = OperationList(data["operation"])
+                    else:
+                        self._operation_list = None
+                    self._step += 1
+                case "ActionChiPengGang":
+                    self._events.append(ChiPengGangEvent(data, timestamp))
+                    self._round_state._on_chipenggang(data)  # noqa: SLF001
+                    if ("operation" in data) and len(
+                        data["operation"]["operation_list"],
+                    ) > 0:
+                        self._operation_list = OperationList(data["operation"])
+                    else:
+                        self._operation_list = None
+                    self._step += 1
+                case "ActionAnGangAddGang":
+                    self._events.append(AngangJiagangEvent(data, timestamp))
+                    self._round_state._on_angang_jiagang(data)  # noqa: SLF001
+                    if ("operation" in data) and len(
+                        data["operation"]["operation_list"],
+                    ) > 0:
+                        self._operation_list = OperationList(data["operation"])
+                    else:
+                        self._operation_list = None
+                    self._step += 1
+                case "ActionBaBei":
+                    self._events.append(BabeiEvent(data, timestamp))
+                    self._round_state._on_babei(data)  # noqa: SLF001
+                    if ("operation" in data) and len(
+                        data["operation"]["operation_list"],
+                    ) > 0:
+                        self._operation_list = OperationList(data["operation"])
+                    else:
+                        self._operation_list = None
+                    self._step += 1
+                case "ActionHule":
+                    raise InconsistentMessageError(str(action))
+                case "ActionNoTile":
+                    raise InconsistentMessageError(str(action))
+                case "ActionLiuJu":
+                    raise InconsistentMessageError(str(action))
+                case _:
+                    raise InconsistentMessageError(str(action))
 
     def __init__(
         self,

--- a/src/majsoulrpa/presentation/match/match.py
+++ b/src/majsoulrpa/presentation/match/match.py
@@ -387,6 +387,7 @@ class MatchPresentation(PresentationBase):
                     | ".lq.Lobby.loginSuccess"
                     | ".lq.Lobby.fetchCharacterInfo"
                     | ".lq.Lobby.fetchAllCommonViews"
+                    | ".lq.Lobby.fetchInfo"
                     | ".lq.FastTest.checkNetworkDelay"
                     | ".lq.FastTest.fetchGamePlayerState"
                     | ".lq.FastTest.finishSyncGame"

--- a/src/majsoulrpa/presentation/match/match.py
+++ b/src/majsoulrpa/presentation/match/match.py
@@ -481,11 +481,6 @@ class MatchPresentation(PresentationBase):
             _, name, request, _, timestamp = message
 
             match name:
-                case ".lq.FastTest.syncGame":
-                    # Only when restarting a suspended match
-                    logger.info(message)
-                    self._on_sync_game(message, restore=True)
-                    continue
                 case ".lq.Lobby.fetchCustomizedContestOnlineInfo":
                     # exchanged regularly in the tournament room
                     logger.info(message)

--- a/src/majsoulrpa/presentation/match/match.py
+++ b/src/majsoulrpa/presentation/match/match.py
@@ -146,6 +146,7 @@ class MatchPresentation(PresentationBase):
                     return
                 raise InconsistentMessageError(str(message))
             case ".lq.FastTest.checkNetworkDelay":
+                # frequently exchanged
                 return
             case (
                 ".lq.FastTest.fetchGamePlayerState"

--- a/src/majsoulrpa/presentation/match/match.py
+++ b/src/majsoulrpa/presentation/match/match.py
@@ -398,6 +398,13 @@ class MatchPresentation(PresentationBase):
                 case ".lq.FastTest.syncGame":
                     logger.info(message)
                     self._on_sync_game(message, restore=True)
+                case (
+                    ".lq.ActionPrototype"
+                    | ".lq.FastTest.inputOperation"
+                    | ".lq.FastTest.inputChiPengGang"
+                ):
+                    self._message_queue_client.put_back(message)
+                    break
                 case _:
                     raise InconsistentMessageError(str(message), screenshot)
 

--- a/src/majsoulrpa/presentation/match/match.py
+++ b/src/majsoulrpa/presentation/match/match.py
@@ -368,13 +368,16 @@ class MatchPresentation(PresentationBase):
                     | ".lq.Lobby.fetchClientValue"
                     | ".lq.Lobby.fetchFriendList"
                     | ".lq.Lobby.fetchFriendApplyList"
+                    | ".lq.Lobby.fetchRecentFriend"
                     | ".lq.Lobby.fetchMailInfo"
                     | ".lq.Lobby.fetchDailyTask"
                     | ".lq.Lobby.fetchReviveCoinInfo"
                     | ".lq.Lobby.fetchTitleList"
                     | ".lq.Lobby.fetchBagInfo"
                     | ".lq.Lobby.fetchShopInfo"
+                    | ".lq.Lobby.fetchShopInterval"
                     | ".lq.Lobby.fetchActivityList"
+                    | ".lq.Lobby.fetchActivityInterval"
                     | ".lq.Lobby.fetchAccountActivityData"
                     | ".lq.Lobby.fetchActivityBuff"
                     | ".lq.Lobby.fetchVipReward"
@@ -478,46 +481,6 @@ class MatchPresentation(PresentationBase):
             _, name, request, _, timestamp = message
 
             match name:
-                case (
-                    ".lq.Lobby.oauth2Auth"
-                    | ".lq.Lobby.oauth2Check"
-                    | ".lq.Lobby.oauth2Login"
-                    | ".lq.Lobby.fetchLastPrivacy"
-                    | ".lq.Lobby.fetchServerTime"
-                    | ".lq.Lobby.fetchServerSettings"
-                    | ".lq.Lobby.fetchConnectionInfo"
-                    | ".lq.Lobby.fetchClientValue"
-                    | ".lq.Lobby.fetchFriendList"
-                    | ".lq.Lobby.fetchFriendApplyList"
-                    | ".lq.Lobby.fetchRecentFriend"
-                    | ".lq.Lobby.fetchMailInfo"
-                    | ".lq.Lobby.fetchDailyTask"
-                    | ".lq.Lobby.fetchReviveCoinInfo"
-                    | ".lq.Lobby.fetchTitleList"
-                    | ".lq.Lobby.fetchBagInfo"
-                    | ".lq.Lobby.fetchShopInfo"
-                    | ".lq.Lobby.fetchShopInterval"
-                    | ".lq.Lobby.fetchActivityList"
-                    | ".lq.Lobby.fetchActivityInterval"
-                    | ".lq.Lobby.fetchAccountActivityData"
-                    | ".lq.Lobby.fetchActivityBuff"
-                    | ".lq.Lobby.fetchVipReward"
-                    | ".lq.Lobby.fetchMonthTicketInfo"
-                    | ".lq.Lobby.fetchAchievement"
-                    | ".lq.Lobby.fetchCommentSetting"
-                    | ".lq.Lobby.fetchAccountSettings"
-                    | ".lq.Lobby.fetchModNicknameTime"
-                    | ".lq.Lobby.fetchMisc"
-                    | ".lq.Lobby.fetchAnnouncement"
-                    | ".lq.Lobby.fetchRollingNotice"
-                    | ".lq.Lobby.loginSuccess"
-                    | ".lq.Lobby.fetchCharacterInfo"
-                    | ".lq.Lobby.fetchAllCommonViews"
-                    | ".lq.FastTest.finishSyncGame"
-                ):
-                    # Only when restarting a suspended match
-                    logger.info(message)
-                    continue
                 case ".lq.FastTest.syncGame":
                     # Only when restarting a suspended match
                     logger.info(message)

--- a/src/majsoulrpa/presentation/match/match.py
+++ b/src/majsoulrpa/presentation/match/match.py
@@ -469,6 +469,10 @@ class MatchPresentation(PresentationBase):
 
         if self._prev_presentation is None:
             self._restore(ss, deadline)
+            # As a temporary workaround,
+            # set _prev_presentation to ROOM_GUEST
+            # TODO: Refactor for a proper solution later
+            self._prev_presentation = Presentation.ROOM_GUEST
             return
 
         while True:

--- a/src/majsoulrpa/presentation/match/match.py
+++ b/src/majsoulrpa/presentation/match/match.py
@@ -445,10 +445,6 @@ class MatchPresentation(PresentationBase):
         templates = [Template.open_file(p, browser.zoom_ratio) for p in paths]
         ss = browser.get_screenshot()
         if Template.match_one_of(ss, templates) == -1:
-            # For postmortem.
-            for t in templates:
-                x, y, score = t.best_template_match(ss)
-                print(f"({x}, {y}): score = {score}")  # noqa: T201
             msg = "Could not detect `match_main`."
             raise PresentationNotDetectedError(msg, ss)
 


### PR DESCRIPTION
**注意**
暫定対応として復帰後の対局前の画面は友人戦のゲストで固定している。
友人戦のホスト、大会部屋にも対応する正式な処理は別途実装する。

上記対応の理由
対局から前の画面に戻る処理が前の画面を表す`prev_presentation`に依存しており、
修正には`***Presentation`クラス全体の修正が必要になる。
`***Presentation`クラスの修正は本コミットの範囲から外れるため。