### PR TITLE
fix: Liqi error dealing with aka dora

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,13 @@ ruff = "^0.2.0"
 types-protobuf = "^4.24.0.4"
 types-jsonschema = "^4.20.0.0"
 boto3-stubs = { extras = ["s3"], version = "^1.34.11" }
+pytest = "^8.0.1"
 
 [tool.poetry.scripts]
 majsoulrpa_remote_browser = "majsoulrpa.remote_browser._remote_browser:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
 
 [tool.ruff]
 target-version = "py311"

--- a/src/majsoulrpa/presentation/match/_common.py
+++ b/src/majsoulrpa/presentation/match/_common.py
@@ -45,3 +45,7 @@ def parse_action(
     )
 
     return step, name, result
+
+
+def deaka(tile: str) -> str:
+    return tile if tile[0] != "0" else "5" + tile[1:]

--- a/src/majsoulrpa/presentation/match/_common.py
+++ b/src/majsoulrpa/presentation/match/_common.py
@@ -47,5 +47,5 @@ def parse_action(
     return step, name, result
 
 
-def deaka(tile: str) -> str:
+def normalize_akadora(tile: str) -> str:
     return tile if tile[0] != "0" else "5" + tile[1:]

--- a/src/majsoulrpa/presentation/match/match.py
+++ b/src/majsoulrpa/presentation/match/match.py
@@ -2315,11 +2315,12 @@ class MatchPresentation(PresentationBase):
         # Note that only red dora appear in the candidate_dapai_list
         # When 5{m,p,s} and the corresponding red dora are in the hand.
         deaka_candidate_dapai_list = [
-            _common.deaka(tile) for tile in operation.candidate_dapai_list
+            _common.normalize_akadora(tile)
+            for tile in operation.candidate_dapai_list
         ]
         if index < len(self.shoupai):
             if (
-                _common.deaka(self.shoupai[index])
+                _common.normalize_akadora(self.shoupai[index])
                 not in deaka_candidate_dapai_list
             ):
                 raise InvalidOperationError(
@@ -2328,7 +2329,7 @@ class MatchPresentation(PresentationBase):
                 )
         elif index == len(self.shoupai):
             if (
-                _common.deaka(self.zimopai or "")
+                _common.normalize_akadora(self.zimopai or "")
                 not in deaka_candidate_dapai_list
             ):
                 raise InvalidOperationError(

--- a/src/majsoulrpa/presentation/match/match.py
+++ b/src/majsoulrpa/presentation/match/match.py
@@ -2321,18 +2321,18 @@ class MatchPresentation(PresentationBase):
 
         # Note that only red dora appear in the candidate_dapai_list
         # When 5{m,p,s} and the corresponding red dora are in the hand.
-        deaka_candidate_dapai_list = [
+        normalized_candidate_dapai_list = [
             _common.normalize_akadora(tile)
             for tile in operation.candidate_dapai_list
         ]
         if (
             index < len(self.shoupai)
             and _common.normalize_akadora(self.shoupai[index])
-            not in deaka_candidate_dapai_list
+            not in normalized_candidate_dapai_list
         ) or (
             index == len(self.shoupai)
             and _common.normalize_akadora(self.zimopai)
-            not in deaka_candidate_dapai_list
+            not in normalized_candidate_dapai_list
         ):
             raise InvalidOperationError(
                 str(index),

--- a/src/majsoulrpa/presentation/match/match.py
+++ b/src/majsoulrpa/presentation/match/match.py
@@ -2312,14 +2312,25 @@ class MatchPresentation(PresentationBase):
                 self._browser.get_screenshot(),
             ) from e
 
+        # Note that only red dora appear in the candidate_dapai_list
+        # When 5{p,m,s} and the corresponding red dora are in the hand.
+        deaka_candidate_dapai_list = [
+            _common.deaka(tile) for tile in operation.candidate_dapai_list
+        ]
         if index < len(self.shoupai):
-            if self.shoupai[index] not in operation.candidate_dapai_list:
+            if (
+                _common.deaka(self.shoupai[index])
+                not in deaka_candidate_dapai_list
+            ):
                 raise InvalidOperationError(
                     str(index),
                     self._browser.get_screenshot(),
                 )
         elif index == len(self.shoupai):
-            if self.zimopai not in operation.candidate_dapai_list:
+            if (
+                _common.deaka(self.zimopai or "")
+                not in deaka_candidate_dapai_list
+            ):
                 raise InvalidOperationError(
                     str(index),
                     self._browser.get_screenshot(),

--- a/src/majsoulrpa/presentation/match/match.py
+++ b/src/majsoulrpa/presentation/match/match.py
@@ -2313,7 +2313,7 @@ class MatchPresentation(PresentationBase):
             ) from e
 
         # Note that only red dora appear in the candidate_dapai_list
-        # When 5{p,m,s} and the corresponding red dora are in the hand.
+        # When 5{m,p,s} and the corresponding red dora are in the hand.
         deaka_candidate_dapai_list = [
             _common.deaka(tile) for tile in operation.candidate_dapai_list
         ]

--- a/src/majsoulrpa/presentation/match/match.py
+++ b/src/majsoulrpa/presentation/match/match.py
@@ -2312,31 +2312,34 @@ class MatchPresentation(PresentationBase):
                 self._browser.get_screenshot(),
             ) from e
 
+        if self.zimopai is None:
+            msg = "liqi without zimopai"
+            raise InvalidOperationError(
+                msg,
+                self._browser.get_screenshot(),
+            )
+
         # Note that only red dora appear in the candidate_dapai_list
         # When 5{m,p,s} and the corresponding red dora are in the hand.
         deaka_candidate_dapai_list = [
             _common.normalize_akadora(tile)
             for tile in operation.candidate_dapai_list
         ]
-        if index < len(self.shoupai):
-            if (
-                _common.normalize_akadora(self.shoupai[index])
-                not in deaka_candidate_dapai_list
-            ):
-                raise InvalidOperationError(
-                    str(index),
-                    self._browser.get_screenshot(),
-                )
-        elif index == len(self.shoupai):
-            if (
-                _common.normalize_akadora(self.zimopai or "")
-                not in deaka_candidate_dapai_list
-            ):
-                raise InvalidOperationError(
-                    str(index),
-                    self._browser.get_screenshot(),
-                )
-        else:
+        if (
+            index < len(self.shoupai)
+            and _common.normalize_akadora(self.shoupai[index])
+            not in deaka_candidate_dapai_list
+        ) or (
+            index == len(self.shoupai)
+            and _common.normalize_akadora(self.zimopai)
+            not in deaka_candidate_dapai_list
+        ):
+            raise InvalidOperationError(
+                str(index),
+                self._browser.get_screenshot(),
+            )
+
+        if index > len(self.shoupai):
             msg = f"{index}: out-of-range index"
             raise InvalidOperationError(msg, self._browser.get_screenshot())
 

--- a/tests/test_presentation/test_match.py
+++ b/tests/test_presentation/test_match.py
@@ -13,6 +13,7 @@ def test_operate_liqi() -> None:
     class DummyMatchPresentation(MatchPresentation):
         def __init__(self) -> None:
             self._round_state = MagicMock()
+            self._browser = MagicMock()
 
         def _dapai(self, index: int, dapai: list[str]) -> None:
             pass
@@ -26,7 +27,6 @@ def test_operate_liqi() -> None:
         return_value=MagicMock(),
     ):
         presentation = DummyMatchPresentation()
-        presentation._browser = MagicMock()
         presentation._round_state.shoupai = [  # type: ignore  # noqa: PGH003
             "2m",
             "7m",

--- a/tests/test_presentation/test_match.py
+++ b/tests/test_presentation/test_match.py
@@ -15,7 +15,7 @@ def test_operate_liqi() -> None:
             self._round_state = MagicMock()
             self._browser = MagicMock()
 
-        def _dapai(self, index: int, dapai: list[str]) -> None:
+        def _dapai(self, index: int, forbidden_tiles: list[str]) -> None:
             pass
 
     op = LiqiOperation(combinations=["0s"])

--- a/tests/test_presentation/test_match.py
+++ b/tests/test_presentation/test_match.py
@@ -122,8 +122,8 @@ def test_operate_liqi__after_gang() -> None:
             "3m",
             "3m",
             "3m",
-            "5p",
             "0p",
+            "5p",
             "6p",
             "1z",
         ]
@@ -146,8 +146,8 @@ def test_operate_liqi__after_gang() -> None:
             "3m",
             "3m",
             "3m",
-            "5p",
             "0p",
+            "5p",
             "6p",
             "1z",
         ]
@@ -167,8 +167,8 @@ def test_operate_liqi__after_gang() -> None:
 
         # Case3: Same as case2 but 1m, 2m and 3m are gang.
         presentation._round_state.shoupai = [  # type: ignore  # noqa: PGH003
-            "5p",
             "0p",
+            "5p",
             "6p",
             "1z",
         ]

--- a/tests/test_presentation/test_match.py
+++ b/tests/test_presentation/test_match.py
@@ -24,7 +24,7 @@ def test_operate_liqi() -> None:
         Template,
         "open_file",
         return_value=MagicMock(),
-    ), patch.object(Template, "wait_for_then_click", return_value=None):
+    ):
         presentation = DummyMatchPresentation()
         presentation._browser = MagicMock()
         presentation._round_state.shoupai = [  # type: ignore  # noqa: PGH003

--- a/tests/test_presentation/test_match.py
+++ b/tests/test_presentation/test_match.py
@@ -1,0 +1,58 @@
+# ruff: noqa: S101,SLF001
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from majsoulrpa._impl.template import Template
+from majsoulrpa.presentation.exceptions import InvalidOperationError
+from majsoulrpa.presentation.match import MatchPresentation
+from majsoulrpa.presentation.match.operation import LiqiOperation
+
+
+def test_operate_liqi() -> None:
+    class DummyMatchPresentation(MatchPresentation):
+        def __init__(self) -> None:
+            self._round_state = MagicMock()
+
+        def _dapai(self, index: int, dapai: list[str]) -> None:
+            pass
+
+    op = LiqiOperation(combinations=["0s"])
+    assert op.candidate_dapai_list == ["0s"]
+
+    with patch.object(
+        Template,
+        "open_file",
+        return_value=MagicMock(),
+    ), patch.object(Template, "wait_for_then_click", return_value=None):
+        presentation = DummyMatchPresentation()
+        presentation._browser = MagicMock()
+        presentation._round_state.shoupai = [  # type: ignore  # noqa: PGH003
+            "2m",
+            "7m",
+            "8m",
+            "9m",
+            "3p",
+            "4p",
+            "5p",
+            "4s",
+            "0s",  # <- index=8
+            "5s",  # <- index=9
+            "6s",
+            "9s",
+            "9s",
+        ]
+        presentation._round_state._zimopai = "1m"
+
+        try:
+            presentation._operate_liqi(op, 8)
+        except InvalidOperationError:
+            pytest.fail("InvalidOperationError raised unexpectedly")
+
+        try:
+            presentation._operate_liqi(op, 9)
+        except InvalidOperationError:
+            pytest.fail("InvalidOperationError raised unexpectedly")
+
+        with pytest.raises(InvalidOperationError):
+            presentation._operate_liqi(op, 7)

--- a/tests/test_presentation/test_match.py
+++ b/tests/test_presentation/test_match.py
@@ -104,7 +104,7 @@ def test_operate_liqi() -> None:
             presentation._operate_liqi(op, 9)
 
 
-def test_operate_liqi__after_kong() -> None:
+def test_operate_liqi__after_gang() -> None:
     op = LiqiOperation(combinations=["0p"])
     assert op.candidate_dapai_list == ["0p"]
 
@@ -114,7 +114,7 @@ def test_operate_liqi__after_kong() -> None:
         return_value=MagicMock(),
     ):
         presentation = DummyMatchPresentation()
-        # Case1: 1m is a kong
+        # Case1: 1m is a gang
         presentation._round_state.shoupai = [  # type: ignore  # noqa: PGH003
             "2m",
             "2m",
@@ -141,7 +141,7 @@ def test_operate_liqi__after_kong() -> None:
             with pytest.raises(InvalidOperationError):
                 presentation._operate_liqi(op, index)
 
-        # Case2: Same as case1 but 1m and 2m are kong.
+        # Case2: Same as case1 but 1m and 2m are gang.
         presentation._round_state.shoupai = [  # type: ignore  # noqa: PGH003
             "3m",
             "3m",
@@ -165,7 +165,7 @@ def test_operate_liqi__after_kong() -> None:
             with pytest.raises(InvalidOperationError):
                 presentation._operate_liqi(op, index)
 
-        # Case3: Same as case2 but 1m, 2m and 3m are kong.
+        # Case3: Same as case2 but 1m, 2m and 3m are gang.
         presentation._round_state.shoupai = [  # type: ignore  # noqa: PGH003
             "5p",
             "0p",
@@ -186,7 +186,7 @@ def test_operate_liqi__after_kong() -> None:
             with pytest.raises(InvalidOperationError):
                 presentation._operate_liqi(op, index)
 
-        # Case4: Same as case3 but 1m, 2m, 3m and 4m are kong.
+        # Case4: Same as case3 but 1m, 2m, 3m and 4m are gang.
         op = LiqiOperation(combinations=["0p", "1z"])
         assert op.candidate_dapai_list == ["0p", "1z"]
         presentation._round_state.shoupai = [  # type: ignore  # noqa: PGH003

--- a/tests/test_presentation/test_match.py
+++ b/tests/test_presentation/test_match.py
@@ -42,7 +42,7 @@ def test_operate_liqi() -> None:
             "9s",
             "9s",
         ]
-        presentation._round_state._zimopai = "1m"
+        presentation._round_state.zimopai = "1m"  # type: ignore  # noqa: PGH003
 
         try:
             presentation._operate_liqi(op, 8)
@@ -56,3 +56,48 @@ def test_operate_liqi() -> None:
 
         with pytest.raises(InvalidOperationError):
             presentation._operate_liqi(op, 7)
+
+        # Test to discard zimopai. 05s are only allowed to be discarded.
+        with pytest.raises(InvalidOperationError):
+            presentation._operate_liqi(op, 13)
+
+        # Case2: Same hand but different zimopai.
+        op = LiqiOperation(combinations=["0s"])
+        assert op.candidate_dapai_list == ["0s"]
+
+        presentation = DummyMatchPresentation()
+        presentation._round_state.shoupai = [  # type: ignore  # noqa: PGH003
+            "1m",
+            "2m",
+            "7m",
+            "8m",
+            "9m",
+            "3p",
+            "4p",
+            "5p",
+            "4s",
+            "5s",  # <- index=9
+            "6s",
+            "9s",
+            "9s",
+        ]
+        presentation._round_state.zimopai = "0s"  # type: ignore  # noqa: PGH003
+
+        with pytest.raises(InvalidOperationError):
+            presentation._operate_liqi(op, 8)
+
+        try:
+            presentation._operate_liqi(op, 9)
+        except InvalidOperationError:
+            pytest.fail("InvalidOperationError raised unexpectedly")
+
+        # Test to discard zimopai. 05s are only allowed to be discarded.
+        try:
+            presentation._operate_liqi(op, 13)
+        except InvalidOperationError:
+            pytest.fail("InvalidOperationError raised unexpectedly")
+
+        # Test Liqi operation without zimopai.
+        presentation._round_state.zimopai = None  # type: ignore  # noqa: PGH003
+        with pytest.raises(InvalidOperationError):
+            presentation._operate_liqi(op, 9)

--- a/tests/test_presentation/test_match.py
+++ b/tests/test_presentation/test_match.py
@@ -105,9 +105,6 @@ def test_operate_liqi() -> None:
 
 
 def test_operate_liqi__after_gang() -> None:
-    op = LiqiOperation(combinations=["0p"])
-    assert op.candidate_dapai_list == ["0p"]
-
     with patch.object(
         Template,
         "open_file",
@@ -128,16 +125,19 @@ def test_operate_liqi__after_gang() -> None:
             "1z",
         ]
         presentation._round_state.zimopai = "1z"  # type: ignore  # noqa: PGH003
+        op = LiqiOperation(combinations=["0p", "6p"])
+        assert op.candidate_dapai_list == ["0p", "6p"]
 
         # valid index
         try:
             presentation._operate_liqi(op, 6)
             presentation._operate_liqi(op, 7)
+            presentation._operate_liqi(op, 8)
         except InvalidOperationError:
             pytest.fail("InvalidOperationError raised unexpectedly")
 
         # invalid index
-        for index in [0, 1, 2, 3, 4, 5, 8, 9, 10]:
+        for index in [0, 1, 2, 3, 4, 5, 9, 10]:
             with pytest.raises(InvalidOperationError):
                 presentation._operate_liqi(op, index)
 
@@ -152,16 +152,19 @@ def test_operate_liqi__after_gang() -> None:
             "1z",
         ]
         presentation._round_state.zimopai = "1z"  # type: ignore  # noqa: PGH003
+        op = LiqiOperation(combinations=["0p", "6p"])
+        assert op.candidate_dapai_list == ["0p", "6p"]
 
         # valid index
         try:
             presentation._operate_liqi(op, 3)
             presentation._operate_liqi(op, 4)
+            presentation._operate_liqi(op, 5)
         except InvalidOperationError:
             pytest.fail("InvalidOperationError raised unexpectedly")
 
         # invalid index
-        for index in [0, 1, 2, 5, 6, 7]:
+        for index in [0, 1, 2, 6, 7]:
             with pytest.raises(InvalidOperationError):
                 presentation._operate_liqi(op, index)
 
@@ -173,26 +176,29 @@ def test_operate_liqi__after_gang() -> None:
             "1z",
         ]
         presentation._round_state.zimopai = "1z"  # type: ignore  # noqa: PGH003
+        op = LiqiOperation(combinations=["0p", "6p"])
+        assert op.candidate_dapai_list == ["0p", "6p"]
 
         # valid index
         try:
             presentation._operate_liqi(op, 0)
             presentation._operate_liqi(op, 1)
+            presentation._operate_liqi(op, 2)
         except InvalidOperationError:
             pytest.fail("InvalidOperationError raised unexpectedly")
 
         # invalid index
-        for index in [2, 3, 4]:
+        for index in [3, 4]:
             with pytest.raises(InvalidOperationError):
                 presentation._operate_liqi(op, index)
 
         # Case4: Same as case3 but 1m, 2m, 3m and 4m are gang.
-        op = LiqiOperation(combinations=["0p", "1z"])
-        assert op.candidate_dapai_list == ["0p", "1z"]
         presentation._round_state.shoupai = [  # type: ignore  # noqa: PGH003
             "5p",
         ]
         presentation._round_state.zimopai = "1z"  # type: ignore  # noqa: PGH003
+        op = LiqiOperation(combinations=["0p", "1z"])
+        assert op.candidate_dapai_list == ["0p", "1z"]
 
         # valid index
         try:


### PR DESCRIPTION
立直時のエラーを解消するためのPRです。

## エラー発生条件

赤ドラと対応する5の数牌が手牌にあり、かつこれらが立直時の打牌候補であるときに `InvalidOperation` 例外が発生します。
例外の発生場所は `MatchPresentation` の `_operate_liqi()` 内の `candidate_dapai_list` に対するバリデーション処理です。

具体例として、以下の状態で例外が発生します。

```
shoupai = ["2m", "7m", "8m", "9m", "3p", "4p", "5p", "4s", "0s", "5s", "6s", "9s", "9s"]
zimopai = 1m
op = LiqiOperation(candidate_dapai_list=["0s"])
index = 9  # 5s
```

これは LiqiOperation インスタンスを作成するときに与えられるデータに赤ドラの `0s` のみが `data["combinations"]: list[str]` として受け取り、`5s` が含まれていないために発生します。

## 実装

_common.py に赤ドラを対応する5の数牌に変換する関数 `deaka()` を定義し、これに適用したあとで `candidate_dapai_list` に対するバリデーション処理を実行するよう修正しました。

### テストの追加

勝手ながら `_operate_liqi()` に対する単体テストを追加しましたがどうでしょうか？
今後単体テストを追加するしない、テストフレームワークやテスト方法など方針がありましたら指摘ください。