### PR TITLE
fix: shoupai not sorted

### DIFF
--- a/src/majsoulrpa/presentation/match/state.py
+++ b/src/majsoulrpa/presentation/match/state.py
@@ -99,11 +99,13 @@ class RoundState:
         self._dora_indicators = data["doras"]
         self._left_tile_count = data["left_tile_count"]
         self._scores = data["scores"]
-        self._shoupai = data["tiles"][:13]
-        if len(data["tiles"]) == 14:
-            self._zimopai = data["tiles"][13]
-        else:
-            self._zimopai = None
+
+        _shouapi = self._sort_tiles(data["tiles"])
+        self._shoupai = _shouapi[:13]
+        self._zimopai: str | None = None
+        if len(_shouapi) == 14:
+            self._zimopai = _shouapi[13]
+
         self._num_player = len(self._scores)
         self._he: list[list] = [[] for _ in range(self._num_player)]
         self._fulu: list[list] = [[] for _ in range(self._num_player)]
@@ -129,13 +131,14 @@ class RoundState:
         self._zimopai = None
 
         # sort the hand
-        shoupai = [
-            RoundState._pattern1.sub(r"\2\1@", t) for t in self._shoupai
-        ]
+        self._shoupai = self._sort_tiles(self._shoupai)
+
+    def _sort_tiles(self, tiles: list[str]) -> list[str]:
+        shoupai = [RoundState._pattern1.sub(r"\2\1@", t) for t in tiles]
         shoupai = [RoundState._pattern2.sub(r"\g<1>5!", t) for t in shoupai]
         shoupai.sort()
         shoupai = [RoundState._pattern3.sub(r"0\1", t) for t in shoupai]
-        self._shoupai = [RoundState._pattern4.sub(r"\2\1", t) for t in shoupai]
+        return [RoundState._pattern4.sub(r"\2\1", t) for t in shoupai]
 
     def _on_zimo(self, data: Mapping[str, Any]) -> None:
         if data["seat"] == self._match_state.seat:

--- a/tests/test_presentation/match/test_state.py
+++ b/tests/test_presentation/match/test_state.py
@@ -1,0 +1,69 @@
+# ruff: noqa: S101,SLF001
+from majsoulrpa.presentation.match.state import MatchState, RoundState
+
+
+def test_round_state() -> None:
+    match_state = MatchState()
+    match_state._seat = 0
+    round_state = RoundState(
+        match_state,
+        data={
+            "chang": 0,
+            "ju": 0,
+            "ben": 0,
+            "liqibang": 0,
+            "doras": ["2z"],
+            "left_tile_count": 70,
+            "scores": [25000, 25000, 25000, 25000],
+            "tiles": [
+                "5s",
+                "2m",
+                "6m",
+                "6z",
+                "6z",
+                "8m",
+                "6z",
+                "5s",
+                "5z",
+                "8p",
+                "6p",
+                "6s",
+                "1s",
+                "3p",
+            ],
+        },
+    )
+
+    assert round_state.zimopai == "6z"
+    assert round_state.shoupai[0] == "2m"
+
+    round_state._shoupai = [
+        "2m",
+        "7m",
+        "8m",
+        "9m",
+        "3p",
+        "4p",
+        "5p",
+        "4s",
+        "0s",
+        "5s",
+        "6s",
+        "9s",
+        "9s",
+    ]
+    round_state._zimopai = "1m"
+    round_state._on_dapai(
+        {
+            "seat": 0,
+            "moqie": False,
+            "tile": "5s",
+            "doras": [],
+            "is_liqi": False,
+            "is_wliqi": False,
+        },
+    )
+    assert round_state.zimopai is None
+    assert round_state.shoupai[0] == "1m"
+    assert "0s" in round_state.shoupai
+    assert "5s" not in round_state.shoupai


### PR DESCRIPTION
最初の配牌時に手牌がソートされない問題を解消するPRです。

最初の配牌は ActionNewRound からソートされていない 13 あるいは 14 枚の牌を受け取ります。現在の実装では ActionNewRound から得られたデータをソートせず `self._shoupai` に割り当てており、これは打牌が実行されたあとの`_hand_in()` が呼ばれるまでソートされません。

これはダブルリーチを打つときに特に問題となります。ソートされていない `self._shoupai` を用いて `MatchPresentation` の `_operate_liqi()` 内のバリデーション処理が実行されます。majsoulrpa で管理するインデックス位置と画面上の理牌された位置の不一致があるため、高い確率でエラー（`InvalidOperation` 例外を出す）となります。

## 実装

NewRoundEvent の shoupai をソートするよう修正します。`_hand_in()` と RoundState のコンストラクタで同じ処理を行うため、メソッドとしてソート処理を切り出しています。