### PR TITLE
Refactor/replace jsonschema refresolver

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -728,3 +728,31 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
+
+## referencing
+
+**Source**: [https://github.com/python-jsonschema/referencing](https://github.com/python-jsonschema/referencing)
+
+**License**:
+
+```text
+Copyright (c) 2022 Julian Berman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```

--- a/poetry.lock
+++ b/poetry.lock
@@ -2268,4 +2268,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "8511a416ffb8d36271142e6a2a9f53d09f20ee7c8f1c5616a1fc1f09bf56dbe5"
+content-hash = "63fa0c02ce0781d6d5d3a949025415d658f11ccbd16596dbb53b7c7173ec2c0e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ protobuf = "^4.25.1"
 jsonschema = "^4.20.0"
 boto3 = "^1.34.11"
 pyzmq = "^26.0.0"
+referencing = "^0.34.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.8.0"

--- a/src/majsoulrpa/config/authentication_imap.json
+++ b/src/majsoulrpa/config/authentication_imap.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": [
         "email_address",

--- a/src/majsoulrpa/config/authentication_s3.json
+++ b/src/majsoulrpa/config/authentication_s3.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": [
         "method",

--- a/src/majsoulrpa/config/browser.json
+++ b/src/majsoulrpa/config/browser.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "properties": {
         "viewport_height": {

--- a/src/majsoulrpa/config/port.json
+++ b/src/majsoulrpa/config/port.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "properties": {
         "remote_port": {

--- a/src/majsoulrpa/config/schema.json
+++ b/src/majsoulrpa/config/schema.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "file:schema.json",
     "title": "ConfigFileValidation",
     "description": "Schema for validating config file",
     "type": "object",


### PR DESCRIPTION
`jsonschema.RefResolver` が非推奨となったため、 `referencing.Registry` で置き換える。
参考: https://github.com/python-jsonschema/referencing/issues/87