### PR TITLE
fix: Discard the message when closing the announcement

### DIFF
--- a/src/majsoulrpa/presentation/home.py
+++ b/src/majsoulrpa/presentation/home.py
@@ -454,6 +454,10 @@ class HomePresentation(PresentationBase):
                     # rewards
                     logger.info(message)
                     continue
+                case ".lq.Lobby.readAnnouncement":
+                    # Exchanged if the notification dialog gets closed
+                    logger.info(message)
+                    continue
                 case _:
                     raise InconsistentMessageError(
                         str(message),


### PR DESCRIPTION
ホーム画面にて告知を×ボタンで閉じた瞬間に `.lq.Lobby.readAnnouncement` がやり取りされるが、受け取れていなかった問題を修正する