### PR TITLE
Fix/fetchVoteActivity

### DIFF
--- a/src/majsoulrpa/presentation/home.py
+++ b/src/majsoulrpa/presentation/home.py
@@ -320,6 +320,7 @@ class HomePresentation(PresentationBase):
                     | ".lq.Lobby.fetchCustomizedContestOnlineInfo"
                     | ".lq.Lobby.startCustomizedContest"
                     | ".lq.Lobby.stopCustomizedContest"
+                    | ".lq.Lobby.fetchVoteActivity"
                 ):
                     logger.info(message)
                     continue

--- a/src/majsoulrpa/presentation/match/match.py
+++ b/src/majsoulrpa/presentation/match/match.py
@@ -402,6 +402,7 @@ class MatchPresentation(PresentationBase):
                     | ".lq.FastTest.checkNetworkDelay"
                     | ".lq.FastTest.fetchGamePlayerState"
                     | ".lq.FastTest.finishSyncGame"
+                    | ".lq.Lobby.fetchVoteActivity"
                 ):
                     logger.info(message)
                 case ".lq.FastTest.authGame":


### PR DESCRIPTION
## 概要

着せ替え復刻投票 (The Limited-time Return of Favorite Outfits Voting Event) の期間中やり取りされる API ".lq.Lobby.fetchVoteActivity" への対応を追加する

## 詳細

".lq.Lobby.fetchVoteActivity" のやり取りされるタイミング
- ログイン時
- 順位更新時間 ( 06:00:00, 07:00:00 のように 1 時間ごと ) をまたいだ後イベント画面を開いた時 ※ イベント画面を開かない限りやり取りされない

よって RPA としてはログイン時のみ対応する