### PR TITLE
Refactor

### DIFF
--- a/src/majsoulrpa/config/_config.py
+++ b/src/majsoulrpa/config/_config.py
@@ -74,7 +74,7 @@ def get_config(path: str | Path) -> dict[str, Any]:
     for i, c in enumerate(config_list):
         name = c["name"]
         print(f"{i}: {name}")  # noqa: T201
-    print("")  # noqa: T201
+    print()  # noqa: T201
 
     selection = int(input("Which configuration to use?: "))
     if selection < 0 or selection >= len(config_list):

--- a/src/majsoulrpa/presentation/presentation_base.py
+++ b/src/majsoulrpa/presentation/presentation_base.py
@@ -56,7 +56,7 @@ class PresentationBase(metaclass=ABCMeta):
         """
         self._rpa = rpa
         self._creator: PresentationCreatorBase = creator
-        self._new_presentation: "PresentationBase | None" = None
+        self._new_presentation: PresentationBase | None = None
 
     def _set_new_presentation(
         self,


### PR DESCRIPTION
ruff check の指摘部分を修正する

- `print` 関数で改行を出力する場合空文字列の指定は不要なので引数を削除する
- `__init__` 内で自身の型の型アノテーションの文字列での指定は不要なので通常の型アノテーションに変更する