### PR TITLE
Fix: `user_data_dir` saved data to wrong location

### DIFF
--- a/src/majsoulrpa/_impl/browser.py
+++ b/src/majsoulrpa/_impl/browser.py
@@ -185,13 +185,12 @@ class DesktopBrowser(BrowserBase):
         mute_audio_off = None if headless else ["--mute-audio"]
 
         self._context_manager = sync_playwright()
-        
+
         self._browser = None
         if user_data_dir:
             if isinstance(user_data_dir, str):
                 user_data_dir = Path(user_data_dir)
-            if not user_data_dir.is_absolute():
-                user_data_dir = Path.cwd() / user_data_dir
+            user_data_dir = user_data_dir.resolve()
             self._context = self._context_manager.start().chromium.launch_persistent_context(  # noqa: E501
                 user_data_dir,
                 args=options,

--- a/src/majsoulrpa/_impl/browser.py
+++ b/src/majsoulrpa/_impl/browser.py
@@ -186,6 +186,11 @@ class DesktopBrowser(BrowserBase):
 
         self._context_manager = sync_playwright()
 
+        if isinstance(user_data_dir, str):
+            user_data_dir = Path(user_data_dir)
+            if not user_data_dir.is_absolute():
+                user_data_dir = Path.cwd() / user_data_dir
+        
         self._browser = None
         if user_data_dir:
             self._context = self._context_manager.start().chromium.launch_persistent_context(  # noqa: E501

--- a/src/majsoulrpa/_impl/browser.py
+++ b/src/majsoulrpa/_impl/browser.py
@@ -185,14 +185,13 @@ class DesktopBrowser(BrowserBase):
         mute_audio_off = None if headless else ["--mute-audio"]
 
         self._context_manager = sync_playwright()
-
-        if isinstance(user_data_dir, str):
-            user_data_dir = Path(user_data_dir)
-            if not user_data_dir.is_absolute():
-                user_data_dir = Path.cwd() / user_data_dir
         
         self._browser = None
         if user_data_dir:
+            if isinstance(user_data_dir, str):
+                user_data_dir = Path(user_data_dir)
+            if not user_data_dir.is_absolute():
+                user_data_dir = Path.cwd() / user_data_dir
             self._context = self._context_manager.start().chromium.launch_persistent_context(  # noqa: E501
                 user_data_dir,
                 args=options,


### PR DESCRIPTION
Convert `user_data_dir` to correct Path if it is a str instance before sending it to Playwright.

This is a fix for: https://github.com/Apricot-S/majsoulrpa/issues/277