### PR TITLE
fix: Always resolve `user_data_dir` to an absolute path

### DIFF
--- a/src/majsoulrpa/remote_browser/_remote_browser.py
+++ b/src/majsoulrpa/remote_browser/_remote_browser.py
@@ -231,6 +231,10 @@ def launch_remote_browser(
         mute_audio_off = None if headless else ["--mute-audio"]
 
         if user_data_dir:
+            if isinstance(user_data_dir, str):
+                user_data_dir = Path(user_data_dir)
+            user_data_dir = user_data_dir.resolve()
+
             with (
                 sync_playwright() as playwright,
                 playwright.chromium.launch_persistent_context(


### PR DESCRIPTION
#277 の対象は `DesktopBrowser` だけだったが、`majsoulrpa_remote_browser` でも同様の問題が発生するため修正する。