### PR TITLE
chore: Migrate project management tool from rye to uv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -263,4 +263,7 @@ $RECYCLE.BIN/
 requirements.lock
 requirements-dev.lock
 
+# uv
+uv.lock
+
 # End of https://www.toptal.com/developers/gitignore/api/python,venv,windows,macos,linux

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ majsoulrpa_remote_browser = "majsoulrpa.remote_browser._remote_browser:main"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.rye]
+[tool.uv]
 managed = true
 dev-dependencies = [
     "mypy>=1.8.0,<2",


### PR DESCRIPTION
プロジェクトの管理ツールを rye から uv に移行する