### PR TITLE
feat: Change the time between retrying discarding a tile to 0.5 seconds

### DIFF
--- a/src/majsoulrpa/presentation/match/match.py
+++ b/src/majsoulrpa/presentation/match/match.py
@@ -1570,7 +1570,7 @@ class MatchPresentation(PresentationBase):
             top,
             width,
             height,
-            interval=1.0,
+            interval=0.5,
             timeout=25.0,
             edge_sigma=1.0,
         )


### PR DESCRIPTION
打牌でクリックが失敗した際のリトライまでのインターバルは現在 1.0 秒である。
インターバルが 1.0 秒だと待ち時間が最大となったときスムーズに打牌できていないように感じられる。
そこで、待ち時間が最大になっても違和感がない 0.5 秒までインターバルを短縮する。